### PR TITLE
Allow to initialize environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,12 @@ module.exports = function(config) {
     mincerPreprocessor: {
       options: {
         // paths mincer will use to search for assets in
-        paths: []
+        paths: [],
+        // optionally define a function which will receive
+        // the mincer environment to allow you to set further
+        // configuration options or register helpers
+        init: function (environment, options) {
+        }
       }
     }
   });

--- a/index.js
+++ b/index.js
@@ -13,6 +13,10 @@ var createMincerPreprocessor = function(args, config, logger, helper) {
   var environment = new Mincer.Environment();
   options.paths.forEach(environment.appendPath, environment);
 
+  if (config.init) {
+    config.init(environment, options);
+  }
+
   return function(content, file, done) {
     var result = null;
     var map;


### PR DESCRIPTION
This just adds a way to define a function in the configuration which will receive the Environment. This makes it possible, for example, to define custom helpers, or to implement the default asset path helper of the Mincer context. Without this, the preprocessor cannot be used if your assets use asset path or other helpers.
